### PR TITLE
Fixed APPROX_BIRTH_DATE and BIRTH_YEAR to sync with service sector data

### DIFF
--- a/R/generate_dummy_mothers_birth_register.R
+++ b/R/generate_dummy_mothers_birth_register.R
@@ -6,15 +6,16 @@
 #' @param n_patients_minimum PARAM_DESCRIPTION, Default: 100
 #' @param description PARAM_DESCRIPTION, Default: Birth Mother dummy data generator
 #' @param seed PARAM_DESCRIPTION, Default: 13
-#' @param birth_mother PARAM_DESCRIPTION, Default: NULL
+#' @param service_sector_data PARAM_DESCRIPTION, Default: NULL
 #' @return list of created tables
 #' @export
-#' @importFrom dplyr rename
+#' @importFrom dplyr mutate arrange desc distinct transmute left_join if_else select rename
+#' @importFrom lubridate as_date dyears make_date days year
 generate_dummy_mothers_birth_register_data <- function(
     birth_mother_level_data_version="R10v3",
     n_patients_minimum = 100,
     seed=13,
-    birth_mother_data = NULL
+    service_sector_data = NULL
 ) {
 
   #set seed
@@ -31,8 +32,36 @@ generate_dummy_mothers_birth_register_data <- function(
   birth_tables <- summary_data_versions_list[[birth_mother_level_data_version]]
   birth_mother_data <- scanReportToTibble(birth_tables$birth_mother$ScanReport_birth_mother, n_patients_minimum)
 
+  # APPROX_BIRTH_DATE column gives out the information when mother gave birth
+  # All of them are NA. To fix this we use service sector data
+  # From service sector data, we calculate bday using APPROX_EVENT_DAY and EVENT_AGE
+  # Using this bday column from service sector data, we can calculate APPROX_BIRTH_DATE as bday + MOTHER_AGE
+  if(!is.null(service_sector_data)){
+
+    # summary from service_sector_data
+    ss_summary <- service_sector_data |>
+      dplyr::arrange(dplyr::desc(APPROX_EVENT_DAY)) |>
+      dplyr::distinct(FINNGENID, .keep_all = T) |>
+      dplyr::transmute(
+        FINNGENID = FINNGENID,
+        bday = lubridate::as_date(APPROX_EVENT_DAY - lubridate::dyears(EVENT_AGE))
+      )
+
+    # APPROX_BIRTH_DATE of child is calculated based on MOTHER birth date from service sector data and MOTHER_AGE
+    # If MOTHER birth date from service sector is NULL then decimal value of MOTHER_AGE is converted to days and added to BIRTH_YEAR
+    # BIRTH_YEAR of child is recalculated from calculated APPROX_BIRTH_DATE of the child
+    birth_mother_data <- birth_mother_data |>
+      dplyr::left_join(ss_summary, by="FINNGENID") |>
+      dplyr::mutate(
+        APPROX_BIRTH_DATE = dplyr::if_else(is.na(bday), lubridate::make_date(as.numeric(BIRTH_YEAR),1,1) + lubridate::days(round(abs(as.numeric(MOTHER_AGE) - floor(as.numeric(MOTHER_AGE))) * 365.24)), lubridate::as_date(bday + lubridate::dyears(as.numeric(MOTHER_AGE)))),
+        BIRTH_YEAR = lubridate::year(APPROX_BIRTH_DATE)
+      ) |>
+      dplyr::select(-bday)
+  }
+
   # Change the column from FINNGENID to MOTHER_FINNGENID
-  birth_mother_data <- birth_mother_data |> dplyr::rename("MOTHER_FINNGENID" = "FINNGENID")
+  birth_mother_data <- birth_mother_data |>
+    dplyr::rename("MOTHER_FINNGENID" = "FINNGENID")
 
   return(birth_mother_data)
 


### PR DESCRIPTION
This is for issue #12 

Fixed the `APPROX_BIRTH_DATE` and `BIRTH_YEAR` to be synced with service sector data.

**INITIAL PROBLEM**
For example, when dummy mother data is created, the `BIRTH_YEAR` say is **1973** with `MOTHER_AGE` as **22.0**. But the **service sector birth year** of a mother can be greater than or less than **1951** (1973 - 22). What this means is a **mother** with birthday not in **1951** gave birth to a child in **1973** and her age is **22**. This does not make sense.

**SOLUTION**
`APPROX_BIRTH_DATE` column is calculated based on **service sector birthday** and `MOTHER_AGE` from birth mother data. In the above example, let us say service sector birthday for mother is **1934-09-24** then 

APPROX_BIRTH_DATE = service sector birthday + (MOTHER_AGE) in days
                                   = 1934-09-24 + 8035 days (22 * 365.24) = 1956-09-24

If the service sector birthday of the is not available, then we take the `BIRTH_YEAR` from birth mother data and convert the decimal units of `MOTHER_AGE` into days and add them. For example, `MOTHER_AGE` is **22.01** and `BIRTH_YEAR` is **1980** then

APPROX_BIRTH_DATE = DATE(BIRTH_YEAR,1,1) + days(DECIMAL(MOTHER_AGE))*365.24
                                   = 1980-01-01 + 4 ( 0.01 * 365.24) days = 1980-01-05

After calculating `APPROX_BIRTH_DATE` then `BIRTH_YEAR` is recalculated.

The code is as shown below
https://github.com/FINNGEN/LongitudinalDummyDataGenerator/blob/53d1f6a90ff3ee833a4ef6cbe80ae736bff34661/R/generate_dummy_mothers_birth_register.R#L53-L60

Tested out and it works properly.